### PR TITLE
Fix typo in project name

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.mobileink./migae.urlfetch "0.1.0-SNAPSHOT"
+(defproject org.mobileink/migae.urlfetch "0.1.0-SNAPSHOT"
   :description "migae - Mobile Ink Google App Engine sdk for Clojure."
   :url "https://github.com/migae/urlfetch"
   :min-lein-version "2.0.0"


### PR DESCRIPTION
There was an extra period in the project name
